### PR TITLE
feat: Added recently played tracks and user track count functionality

### DIFF
--- a/Spotify/Spotify/Controllers/UserProfileController.cs
+++ b/Spotify/Spotify/Controllers/UserProfileController.cs
@@ -5,6 +5,9 @@ using System.Threading.Tasks;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
     using Spotify.Data;
+    using Newtonsoft.Json;
+    using System.Net.Http.Headers;
+    using Spotify.Models;
     [Route("api/[controller]")]
 [ApiController]
 public class UserProfileController : ControllerBase
@@ -15,9 +18,32 @@ public class UserProfileController : ControllerBase
     {
         _context = context;
     }
+        [HttpGet("all")]
+        public async Task<IActionResult> GetAllUsers()
+        {
+            var users = await _context.Users
+                .Select(u => new
+                {
+                    u.Id,
+                    u.Email,
+                    u.Gender,
+                    u.BirthDay,
+                    u.BirthMonth,
+                    u.BirthYear,
+                    u.Country,
+                    u.Region,
+                    Role = _context.UserRoles
+                        .Where(ur => ur.UserId == u.Id)
+                        .Select(ur => ur.RoleId)
+                        .FirstOrDefault()
+                })
+                .ToListAsync();
 
-    // Метод для отримання профілю користувача
-    [HttpGet("{userId}")]
+            return Ok(users);
+        }
+
+        // Метод для отримання профілю користувача
+        [HttpGet("{userId}")]
     public async Task<IActionResult> GetUserProfile(string userId)
     {
         var userProfile = await _context.Users
@@ -41,9 +67,87 @@ public class UserProfileController : ControllerBase
 
         return Ok(userProfile);
     }
+        [HttpGet("{userId}/track-count")]
+        public async Task<IActionResult> GetTrackCount(string userId)
+        {
+            var user = await _context.Users.FindAsync(userId);
+            if (user == null)
+            {
+                return NotFound("User not found.");
+            }
 
-    // Метод для оновлення профілю користувача
-    [HttpPut("{userId}")]
+            var trackCount = await _context.PlayedTracks
+                .Where(pt => pt.UserId == userId)
+                .CountAsync();
+
+            return Ok(new { trackCount });
+        }
+
+        [HttpGet("{userId}/recently-played")]
+        public async Task<IActionResult> GetRecentlyPlayedTracks(string userId)
+        {
+            var user = await _context.Users.FindAsync(userId);
+            if (user == null || string.IsNullOrEmpty(user.AccessToken))
+            {
+                return NotFound("User not found or no access token available.");
+            }
+
+            try
+            {
+                // Отримуємо недавно прослухані треки через Spotify API
+                using var client = new HttpClient();
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", user.AccessToken);
+
+                var response = await client.GetAsync("https://api.spotify.com/v1/me/player/recently-played");
+                if (!response.IsSuccessStatusCode)
+                {
+                    return StatusCode((int)response.StatusCode, "Failed to retrieve recently played tracks.");
+                }
+
+                var jsonResponse = await response.Content.ReadAsStringAsync();
+                var recentlyPlayed = JsonConvert.DeserializeObject<dynamic>(jsonResponse);
+
+                // Зберігаємо інформацію про прослухані треки в базі даних
+                foreach (var item in recentlyPlayed.items)
+                {
+                    string trackId = item.track.id;
+                    string trackName = item.track.name;
+
+                    // Логіка для зберігання прослуханих треків у базі
+                    var playedTrack = new PlayedTrack
+                    {
+                        UserId = userId,
+                        TrackId = trackId,
+                        TrackName = trackName,
+                        PlayedAt = item.played_at
+                    };
+
+                    _context.PlayedTracks.Add(playedTrack);
+                }
+
+                await _context.SaveChangesAsync();
+
+                return Ok(new { message = "Recently played tracks saved successfully." });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, $"An error occurred: {ex.Message}");
+            }
+        }
+
+        [HttpGet("{userId}/token")]
+        public async Task<IActionResult> GetUserToken(string userId)
+        {
+            var user = await _context.Users.FindAsync(userId);
+            if (user == null || string.IsNullOrEmpty(user.AccessToken))
+            {
+                return NotFound("Access token not found.");
+            }
+
+            return Ok(new { accessToken = user.AccessToken });
+        }
+        // Метод для оновлення профілю користувача
+        [HttpPut("{userId}")]
     public async Task<IActionResult> UpdateUserProfile(string userId, [FromBody] UserProfileUpdateDto updateDto)
     {
         var user = await _context.Users.FindAsync(userId);

--- a/Spotify/Spotify/Data/ApplicationDbContext.cs
+++ b/Spotify/Spotify/Data/ApplicationDbContext.cs
@@ -10,6 +10,7 @@ namespace Spotify.Data
             : base(options)
         {
         }
+        public DbSet<PlayedTrack> PlayedTracks { get; set; }
 
     }
 }

--- a/Spotify/Spotify/Migrations/20241004183231_Tokens.Designer.cs
+++ b/Spotify/Spotify/Migrations/20241004183231_Tokens.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Spotify.Data;
 
@@ -11,9 +12,11 @@ using Spotify.Data;
 namespace Spotify.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241004183231_Tokens")]
+    partial class Tokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -254,34 +257,6 @@ namespace Spotify.Migrations
                     b.HasKey("UserId", "LoginProvider", "Name");
 
                     b.ToTable("AspNetUserTokens", (string)null);
-                });
-
-            modelBuilder.Entity("Spotify.Models.PlayedTrack", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
-
-                    b.Property<DateTime>("PlayedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("TrackId")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("TrackName")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("UserId")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("PlayedTracks");
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>

--- a/Spotify/Spotify/Migrations/20241004183231_Tokens.cs
+++ b/Spotify/Spotify/Migrations/20241004183231_Tokens.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Spotify.Migrations
+{
+    /// <inheritdoc />
+    public partial class Tokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Images");
+
+            migrationBuilder.DropTable(
+                name: "Tracks");
+
+            migrationBuilder.DropTable(
+                name: "Playlists");
+
+            migrationBuilder.AddColumn<string>(
+                name: "AccessToken",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "RefreshToken",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "TokenExpiration",
+                table: "AspNetUsers",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AccessToken",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "RefreshToken",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "TokenExpiration",
+                table: "AspNetUsers");
+
+            migrationBuilder.CreateTable(
+                name: "Images",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Category = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ImagePath = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Images", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Playlists",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ImagePath = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    IsFavorite = table.Column<bool>(type: "bit", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Playlists", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Tracks",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    PlaylistId = table.Column<int>(type: "int", nullable: false),
+                    Artist = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Duration = table.Column<TimeSpan>(type: "time", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Tracks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Tracks_Playlists_PlaylistId",
+                        column: x => x.PlaylistId,
+                        principalTable: "Playlists",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tracks_PlaylistId",
+                table: "Tracks",
+                column: "PlaylistId");
+        }
+    }
+}

--- a/Spotify/Spotify/Migrations/20241004192420_CountTracks.Designer.cs
+++ b/Spotify/Spotify/Migrations/20241004192420_CountTracks.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Spotify.Data;
 
@@ -11,9 +12,11 @@ using Spotify.Data;
 namespace Spotify.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241004192420_CountTracks")]
+    partial class CountTracks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Spotify/Spotify/Migrations/20241004192420_CountTracks.cs
+++ b/Spotify/Spotify/Migrations/20241004192420_CountTracks.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Spotify.Migrations
+{
+    /// <inheritdoc />
+    public partial class CountTracks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PlayedTracks",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserId = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    TrackId = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    TrackName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    PlayedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PlayedTracks", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PlayedTracks");
+        }
+    }
+}

--- a/Spotify/Spotify/Models/ApplicationUser.cs
+++ b/Spotify/Spotify/Models/ApplicationUser.cs
@@ -9,5 +9,8 @@ public class ApplicationUser : IdentityUser
     public string? Region { get; set; }
     public string? Gender { get; set; }
     public string? FullName { get; set; }
+    public string AccessToken { get; set; } // Поле для збереження AccessToken
+    public string RefreshToken { get; set; } // Поле для збереження RefreshToken, якщо потрібно
+    public DateTime TokenExpiration { get; set; } // Поле для збереження часу закінчення токена
 }
 

--- a/Spotify/Spotify/Models/PlayedTrack.cs
+++ b/Spotify/Spotify/Models/PlayedTrack.cs
@@ -1,0 +1,12 @@
+﻿namespace Spotify.Models
+{
+    public class PlayedTrack
+    {
+        public int Id { get; set; }
+        public string UserId { get; set; }
+        public string TrackId { get; set; }
+        public string TrackName { get; set; }
+        public DateTime PlayedAt { get; set; }
+    }
+
+}

--- a/my-front/src/App.tsx
+++ b/my-front/src/App.tsx
@@ -25,6 +25,7 @@ import LoadingTrackPage from './components/Loading/LoadingTrackPage';
 import UploadImages from './services/UploadImages';
 import { ThemeProvider } from './services/ThemeContext';
 import { LanguageProvider } from './services/LanguageContext';
+import AdminPanel from './components/Admin/AdminPanel';
 
 const App: React.FC = () => {
   
@@ -38,6 +39,7 @@ const App: React.FC = () => {
       <Route path="/" element={<Layout />}>
         <Route path="/" element={<Login />} />
         <Route path="/callback" element={<Callback />} />
+        <Route path="/admin" element={<AdminPanel />} />
         <Route path="/home" element={<MainPage />} />
         <Route path="/profile" element={<Profile />} />
         <Route path="/categories" element={<Categories />} /> 

--- a/my-front/src/components/Admin/AdminPanel.tsx
+++ b/my-front/src/components/Admin/AdminPanel.tsx
@@ -1,0 +1,299 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+
+interface User {
+  id: string;
+  email: string;
+  gender: string;
+  birthDay: number;
+  birthMonth: string;
+  birthYear: number;
+  country: string;
+  region: string;
+  role: string;
+}
+
+interface Playlist {
+  id: string;
+  name: string;
+  images: { url: string }[];
+  description: string;
+  external_urls: { spotify: string };
+}
+
+interface Track {
+  id: string;
+  name: string;
+  album: {
+    name: string;
+    images: { url: string }[];
+  };
+  artists: { name: string }[];
+  external_urls: { spotify: string };
+  uri: string;
+}
+
+interface Artist {
+  id: string;
+  name: string;
+  images: { url: string }[];
+  external_urls: { spotify: string };
+}
+
+interface Album {
+  id: string;
+  name: string;
+  images: { url: string }[];
+  external_urls: { spotify: string };
+}
+
+const AdminPanel: React.FC = () => {
+  const [users, setUsers] = useState<User[]>([]);
+  const [playlists, setPlaylists] = useState<Playlist[]>([]);
+  const [tracks, setTracks] = useState<Track[]>([]);
+  const [artists, setArtists] = useState<Artist[]>([]); // Додаємо стан для артистів
+  const [albums, setAlbums] = useState<Album[]>([]); // Додаємо стан для альбомів
+  const [selectedUser, setSelectedUser] = useState<User | null>(null);
+  const [newTrackUri, setNewTrackUri] = useState('');
+  const [trackCounts, setTrackCounts] = useState<{ [key: string]: number }>({}); // Стейт для кількості треків
+
+  useEffect(() => {
+    const fetchUsers = async () => {
+      try {
+        const usersResponse = await axios.get('https://localhost:5051/api/UserProfile/all');
+        setUsers(usersResponse.data);
+      } catch (error) {
+        console.error('Error fetching users:', error);
+      }
+    };
+    fetchUsers();
+  }, []);
+
+  const fetchUserPlaylists = async (userId: string) => {
+    try {
+      const tokenResponse = await axios.get(`https://localhost:5051/api/UserProfile/${userId}/token`);
+      const accessToken = tokenResponse.data.accessToken;
+
+      const playlistsResponse = await axios.get('https://api.spotify.com/v1/me/playlists', {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      if (playlistsResponse.data.items && playlistsResponse.data.items.length > 0) {
+        setPlaylists(playlistsResponse.data.items);
+
+        const playlistId = playlistsResponse.data.items[0].id;
+        const tracksResponse = await axios.get(`https://api.spotify.com/v1/playlists/${playlistId}/tracks`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+
+        setTracks(tracksResponse.data.items.map((item: any) => item.track));
+      } else {
+        setPlaylists([]);
+        setTracks([]);
+      }
+    } catch (error) {
+      console.error('Error fetching playlists and tracks:', error);
+    }
+  };
+
+  // Отримання вподобаних артистів
+  const fetchUserLikedArtists = async (userId: string) => {
+    try {
+      const tokenResponse = await axios.get(`https://localhost:5051/api/UserProfile/${userId}/token`);
+      const accessToken = tokenResponse.data.accessToken;
+
+      const artistsResponse = await axios.get('https://api.spotify.com/v1/me/following?type=artist', {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      setArtists(artistsResponse.data.artists.items);
+    } catch (error) {
+      console.error('Error fetching liked artists:', error);
+    }
+  };
+
+  // Отримання вподобаних альбомів
+  const fetchUserLikedAlbums = async (userId: string) => {
+    try {
+      const tokenResponse = await axios.get(`https://localhost:5051/api/UserProfile/${userId}/token`);
+      const accessToken = tokenResponse.data.accessToken;
+
+      const albumsResponse = await axios.get('https://api.spotify.com/v1/me/albums', {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      setAlbums(albumsResponse.data.items.map((item: any) => item.album));
+    } catch (error) {
+      console.error('Error fetching liked albums:', error);
+    }
+  };
+
+  const handleUserSelect = (user: User) => {
+    setSelectedUser(user);
+    fetchUserPlaylists(user.id);
+    fetchUserLikedArtists(user.id); // Отримуємо вподобаних артистів
+    fetchUserLikedAlbums(user.id); // Отримуємо вподобані альбоми
+  };
+
+  const addTrackToPlaylist = async (playlistId: string, trackUri: string) => {
+    try {
+      const tokenResponse = await axios.get(`https://localhost:5051/api/UserProfile/${selectedUser?.id}/token`);
+      const accessToken = tokenResponse.data.accessToken;
+
+      await axios.post(
+        `https://api.spotify.com/v1/playlists/${playlistId}/tracks`,
+        {
+          uris: [trackUri],
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      );
+
+      fetchUserPlaylists(selectedUser!.id);
+    } catch (error) {
+      console.error('Error adding track:', error);
+    }
+  };
+  const fetchTrackCount = async (userId: string) => {
+    try {
+      const response = await axios.get(`https://localhost:5051/api/UserProfile/${userId}/track-count`);
+      setTrackCounts((prevCounts) => ({
+        ...prevCounts,
+        [userId]: response.data.trackCount,
+      }));
+    } catch (error) {
+      console.error('Error fetching track count:', error);
+    }
+  };
+  const removeTrackFromPlaylist = async (playlistId: string, trackUri: string) => {
+    try {
+      const tokenResponse = await axios.get(`https://localhost:5051/api/UserProfile/${selectedUser?.id}/token`);
+      const accessToken = tokenResponse.data.accessToken;
+
+      await axios({
+        method: 'delete',
+        url: `https://api.spotify.com/v1/playlists/${playlistId}/tracks`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        data: {
+          tracks: [{ uri: trackUri }],
+        },
+      });
+
+      fetchUserPlaylists(selectedUser!.id);
+    } catch (error) {
+      console.error('Error removing track:', error);
+    }
+  };
+
+  return (
+    <div>
+      <h1>Admin Panel</h1>
+
+      <h2>Users</h2>
+      <ul>
+        {users.map((user) => (
+          <li key={user.id}>
+            <strong>{user.email}</strong> - {user.role} - {user.country}, {user.region}
+            <button onClick={() => handleUserSelect(user)}>View Playlists and Liked Items</button>
+            <button onClick={() => fetchTrackCount(user.id)}>View Track Count</button>
+            {trackCounts[user.id] !== undefined && (
+              <p>Tracks listened: {trackCounts[user.id]}</p>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      {selectedUser && (
+        <div>
+          <h3>User Details</h3>
+          <p><strong>ID:</strong> {selectedUser.id}</p>
+          <p><strong>Name:</strong> {selectedUser.email}</p>
+          <p><strong>Role:</strong> {selectedUser.role}</p>
+        </div>
+      )}
+
+      <h2>Playlists</h2>
+      {playlists.length > 0 ? (
+        <ul>
+          {playlists.map((playlist) => (
+            <li key={playlist.id}>
+              <img src={playlist.images[0]?.url} alt={playlist.name} style={{ width: '50px', height: '50px' }} />
+              <strong>{playlist.name}</strong> - {playlist.description}
+              <a href={playlist.external_urls.spotify} target="_blank" rel="noopener noreferrer">Open in Spotify</a>
+
+              <div>
+                <input
+                  type="text"
+                  value={newTrackUri}
+                  onChange={(e) => setNewTrackUri(e.target.value)}
+                  placeholder="Track URI"
+                />
+                <button onClick={() => addTrackToPlaylist(playlist.id, newTrackUri)}>Add Track</button>
+              </div>
+
+              <h4>Tracks</h4>
+              <ul>
+                {tracks.map((track) => (
+                  <li key={track.id}>
+                    <img src={track.album.images[0]?.url} alt={track.name} style={{ width: '50px', height: '50px' }} />
+                    <strong>{track.name}</strong> - {track.artists.map(artist => artist.name).join(', ')}
+                    <a href={track.external_urls.spotify} target="_blank" rel="noopener noreferrer">Open in Spotify</a>
+                    <button onClick={() => removeTrackFromPlaylist(playlist.id, track.uri)}>Remove Track</button>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No playlists available.</p>
+      )}
+
+      <h2>Liked Artists</h2>
+      {artists.length > 0 ? (
+        <ul>
+          {artists.map((artist) => (
+            <li key={artist.id}>
+              <img src={artist.images[0]?.url} alt={artist.name} style={{ width: '50px', height: '50px' }} />
+              <strong>{artist.name}</strong>
+              <a href={artist.external_urls.spotify} target="_blank" rel="noopener noreferrer">Open in Spotify</a>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No liked artists available.</p>
+      )}
+
+      <h2>Liked Albums</h2>
+      {albums.length > 0 ? (
+        <ul>
+          {albums.map((album) => (
+            <li key={album.id}>
+              <img src={album.images[0]?.url} alt={album.name} style={{ width: '50px', height: '50px' }} />
+              <strong>{album.name}</strong>
+              <a href={album.external_urls.spotify} target="_blank" rel="noopener noreferrer">Open in Spotify</a>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No liked albums available.</p>
+      )}
+      
+    </div>
+  );
+};
+
+export default AdminPanel;

--- a/my-front/src/components/Player/PlayerControls.tsx
+++ b/my-front/src/components/Player/PlayerControls.tsx
@@ -53,15 +53,14 @@ const PlayerControls: React.FC = () => {
       if (player) {
         player.addListener('ready', ({ device_id }) => {
           console.log('Player is ready with Device ID:', device_id);
-          setCurrentDeviceId(device_id); // Update device ID when the player is ready
+          setCurrentDeviceId(device_id); 
           setIsPlayerReady(true);
         });
-
+    
         player.addListener('not_ready', ({ device_id }) => {
           console.log('Player not ready with Device ID:', device_id);
           setIsPlayerReady(false);
         });
-
         player.addListener('player_state_changed', (state) => {
           if (state) {
             const track = state.track_window.current_track;

--- a/my-front/src/services/PlayerContext.tsx
+++ b/my-front/src/services/PlayerContext.tsx
@@ -1,0 +1,27 @@
+// PlayerContext.tsx
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+interface PlayerContextType {
+  deviceId: string | null;
+  setDeviceId: (id: string) => void;
+}
+
+const PlayerContext = createContext<PlayerContextType | undefined>(undefined);
+
+export const PlayerProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [deviceId, setDeviceId] = useState<string | null>(null);
+
+  return (
+    <PlayerContext.Provider value={{ deviceId, setDeviceId }}>
+      {children}
+    </PlayerContext.Provider>
+  );
+};
+
+export const usePlayerContext = (): PlayerContextType => {
+  const context = useContext(PlayerContext);
+  if (!context) {
+    throw new Error('usePlayerContext must be used within a PlayerProvider');
+  }
+  return context;
+};

--- a/my-front/src/utils/SpotifyPlayer.ts
+++ b/my-front/src/utils/SpotifyPlayer.ts
@@ -36,27 +36,21 @@ export const getActiveDeviceId = async (): Promise<string | null> => {
   }
 };
 
-// Function to play an album
-export const handlePlayAlbum = async (albumUri: string) => {
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+export const handlePlayAlbum = async (albumUri: string, retryCount = 0) => {
   const token = localStorage.getItem('spotifyAccessToken');
-
-  if (!token) {
-    console.error('No access token found');
-    return;
-  }
-
   const deviceId = await getActiveDeviceId();
+
   if (!deviceId) {
-    alert('Please open Spotify on one of your devices to start playback.');
+    alert('No active device found, please start Spotify on one of your devices.');
     return;
   }
 
   try {
     await axios.put(
       `https://api.spotify.com/v1/me/player/play?device_id=${deviceId}`,
-      {
-        context_uri: albumUri,
-      },
+      { context_uri: albumUri },
       {
         headers: {
           Authorization: `Bearer ${token}`,
@@ -64,38 +58,33 @@ export const handlePlayAlbum = async (albumUri: string) => {
         },
       }
     );
-
     console.log('Album is playing');
   } catch (error: any) {
     console.error('Error playing album:', error?.response || error.message || error);
-    if (error.response && error.response.status === 404) {
+    if (error.response && error.response.status === 502 && retryCount < 3) {
       console.log('Retrying to connect player...');
-      setTimeout(() => handlePlayAlbum(albumUri), 2000); // Retry after delay
+      await delay(2000 * (retryCount + 1)); // Exponential backoff
+      handlePlayAlbum(albumUri, retryCount + 1);
     }
   }
 };
 
+
+
 // Function to play a specific track
 export const handlePlayTrack = async (trackUri: string) => {
   const token = localStorage.getItem('spotifyAccessToken');
-
-  if (!token) {
-    console.error('No access token found');
-    return;
-  }
-
   const deviceId = await getActiveDeviceId();
+
   if (!deviceId) {
-    alert('Please open Spotify on one of your devices to start playback.');
+    alert('No active device found, please start Spotify on one of your devices.');
     return;
   }
 
   try {
     await axios.put(
       `https://api.spotify.com/v1/me/player/play?device_id=${deviceId}`,
-      {
-        uris: [trackUri],
-      },
+      { uris: [trackUri] },
       {
         headers: {
           Authorization: `Bearer ${token}`,
@@ -103,16 +92,16 @@ export const handlePlayTrack = async (trackUri: string) => {
         },
       }
     );
-
     console.log('Track is playing');
   } catch (error: any) {
     console.error('Error playing track:', error?.response || error.message || error);
-    if (error.response && error.response.status === 404) {
+    if (error.response && error.response.status === 502) {
       console.log('Retrying to connect player...');
       setTimeout(() => handlePlayTrack(trackUri), 2000); // Retry after delay
     }
   }
 };
+
 // Function to play an array of tracks in sequence
 export const handlePlayTrackList = async (trackUris: string[], startUri?: string) => {
     const token = localStorage.getItem('spotifyAccessToken');


### PR DESCRIPTION
- Created PlayedTrack model to store user listening data
- Implemented logic to fetch recently played tracks from Spotify API and store them in the database
- Added API endpoint to calculate the total number of tracks a user has listened to
- Updated AdminPanel to display track count for each user
- Fixed UI issues with displaying playlists, liked albums, and artists
- Improved error handling for Spotify API calls